### PR TITLE
fix: Build message and-varidator and or-validator.

### DIFF
--- a/clavier.lisp
+++ b/clavier.lisp
@@ -131,7 +131,8 @@
   (:default-initargs
    :type 'string
    :message (lambda (validator object)
-	      (format nil "~A is not a string" object)))
+	      (declare (ignore validator))
+	      (format nil "~S is not a string" object)))
   (:metaclass closer-mop:funcallable-standard-class))
 
 (defclass boolean-validator (type-validator)
@@ -245,9 +246,9 @@
    :message (lambda (validator object)
 	      (format nil "~A or ~A"
 		      (let ((x-validator (x validator)))
-			(funcall (message x-validator) x-validator object))
+			(validator-message x-validator object))
 		      (let ((y-validator (y validator)))
-			(funcall (message y-validator) y-validator object)))))
+			(validator-message y-validator object)))))
   (:metaclass closer-mop:funcallable-standard-class))
 
 (defclass or-validator (validator)
@@ -261,9 +262,9 @@
    :message (lambda (validator object)
 	      (format nil "~A and ~A"
 		      (let ((x-validator (x validator))) 
-			(funcall (message x-validator) x-validator object))
+			(validator-message x-validator object))
 		      (let ((y-validator (y validator)))
-			(funcall (message y-validator) y-validator object)))))
+			(validator-message y-validator object)))))
   (:metaclass closer-mop:funcallable-standard-class))
 
 (defclass one-of-validator (validator)


### PR DESCRIPTION
Use validator-message in and-varidator and or-validator.

This case raise a error.

```common-lisp
(let ((validator (&& (not-blank)
		     (&& (is-a-string)
			 (len :max 5)))))
    (funcall validator ""))
```

Error message:
```common-lisp
"Size is not correct" fell through ETYPECASE expression.
Wanted one of #'SYMBOL.
   [Condition of type SB-KERNEL:CASE-FAILURE]

Restarts:
 0: [RETRY] Retry SLIME REPL evaluation request.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT] Abort thread (#<THREAD "repl-thread" RUNNING {10047280B3}>)

Backtrace:
  0: (SB-KERNEL:CASE-FAILURE ETYPECASE "Size is not correct" (FUNCTION SYMBOL))
  1: (SB-KERNEL:%COERCE-CALLABLE-TO-FUN "Size is not correct")
  2: ((LAMBDA (VALIDATOR OBJECT) :IN "/home/somewrite/quicklisp/dists/quicklisp/software/clavier-20150302-git/clavier.lisp") #<AND-VALIDATOR {1004B3FECB}> "")
  3: ((LAMBDA (VALIDATOR OBJECT) :IN "/home/somewrite/quicklisp/dists/quicklisp/software/clavier-20150302-git/clavier.lisp") #<AND-VALIDATOR {1004B4396B}> "")
  4: (VALIDATE #<AND-VALIDATOR {1004B4396B}> "")
  5: (SB-INT:SIMPLE-EVAL-IN-LEXENV (LET ((VALIDATOR #)) (FUNCALL VALIDATOR "")) #<NULL-LEXENV>)
  6: (EVAL (LET ((VALIDATOR #)) (FUNCALL VALIDATOR "")))
```