### PR TITLE
Modify VALIDATE so that it returns two values on success

### DIFF
--- a/clavier.lisp
+++ b/clavier.lisp
@@ -335,7 +335,7 @@
 	(if error-p
 	    (validation-error object message)
 	    (values nil message)))
-      t))     
+      (values t nil)))
 
 (defgeneric %validate (validator object &rest args))
 (defmethod %validate (validator object &rest args))


### PR DESCRIPTION
Hi Mariano,

Although MULTIPLE-VALUE-BIND gives nil when there are more values, returning a
variable number of values doesn't play well with MULTIPLE-VALUE-CALL.

Also although a bug in CCL's loop implementation code like `(loop :for (validp error) := (multiple-value-list (validate ..)))` would raise an error.