### PR TITLE
len validator: add :message argument

### DIFF
--- a/clavier.lisp
+++ b/clavier.lisp
@@ -564,10 +564,11 @@
 		  ,@(when message
 			  (list :message (apply #'format nil message args))))))
 
-(defun len (&key min max min-message max-message)
+(defun len (&key min max message min-message max-message)
   (make-instance 'length-validator
 		 :min min
 		 :max max
+                 :message message
 		 :min-message min-message
 		 :max-message max-message))
 


### PR DESCRIPTION
There is already :min-message and :max-message, now we can simply use :message. 

```lisp
(clavier:len :min 10 :max 13
     :message "an ISBN must be between 10 and 13 characters long"))
```